### PR TITLE
[HOTFIX] 바텀 다이얼로그 빠르게 연속으로 두 번 클릭 시, 오류 해결

### DIFF
--- a/app/src/main/java/org/cardna/presentation/MainActivity.kt
+++ b/app/src/main/java/org/cardna/presentation/MainActivity.kt
@@ -209,7 +209,6 @@ class MainActivity :
 // 즉, MainActivity 에서 BottomSheetDialog 를 띄워주는 메서드
     fun showBottomDialogCardFragment() {
         // 바텀싯 다이얼로그가 뜬 후, 카드나 or 카드너를 선택했을 때, 그거에 따라 어떤 액티비티를 띄워줘야 하는지를 명세한 Fragment 정의하고
-
         val itemClick : (Boolean) -> Unit  =
             {it ->
                 when (it) {
@@ -238,7 +237,9 @@ class MainActivity :
             )
         }
 
-        bottomDialogCardFragment.show(supportFragmentManager, bottomDialogCardFragment.tag)
+        if(supportFragmentManager.findFragmentByTag(bottomDialogCardFragment.tag) == null) {
+            bottomDialogCardFragment.show(supportFragmentManager, bottomDialogCardFragment.tag)
+        }
     }
 
 

--- a/app/src/main/java/org/cardna/presentation/ui/cardpack/view/CardCreateActivity.kt
+++ b/app/src/main/java/org/cardna/presentation/ui/cardpack/view/CardCreateActivity.kt
@@ -173,21 +173,39 @@ class CardCreateActivity :
     private fun setChooseCardListener() {
         binding.ctlCardcreateImg.setOnClickListener {
             // 이미지 선택 cl 클릭 시, bottomDialogImageFragment 를 생성한 후, 람다를 bundle로 넘겨줌. 이를 show()
+
+            binding.ctlCardcreateImg.isClickable = false
+
             val bottomDialogImageFragment = BottomDialogImageFragment()
             bottomDialogImageFragment.arguments = Bundle().apply {
                 putParcelable(BaseViewUtil.BOTTOM_IMAGE, BottomImageLamdaData(itemClick))
             }
             bottomDialogImageFragment.show(supportFragmentManager, bottomDialogImageFragment.tag)
+
+
+            val handler = Handler(Looper.getMainLooper())
+            handler.postDelayed({
+                binding.ctlCardcreateImg.isClickable = true
+            }, 1000) // 1초 딜레이 후 다시 클릭 가능하도록
         }
 
         // 첫번째 심볼이나 갤러리 이미지 선택 후, 이미지가 보이게 될 것. 그러면 이 이미지뷰를 눌러도 다시 이미지를 선택할 수 있도록
         // 리스너 달아주기
         binding.ivCardcreateGalleryImg.setOnClickListener {
+
+            binding.ivCardcreateGalleryImg.isClickable = false
+
             val bottomDialogImageFragment = BottomDialogImageFragment()
             bottomDialogImageFragment.arguments = Bundle().apply {
                 putParcelable(BaseViewUtil.BOTTOM_IMAGE, BottomImageLamdaData(itemClick))
             }
             bottomDialogImageFragment.show(supportFragmentManager, bottomDialogImageFragment.tag)
+
+
+            val handler = Handler(Looper.getMainLooper())
+            handler.postDelayed({
+                binding.ivCardcreateGalleryImg.isClickable = true
+            }, 1000) // 1초 딜레이 후 다시 클릭 가능하도록
         }
     }
 
@@ -282,7 +300,8 @@ class CardCreateActivity :
                 // 2. cardCreateCompleteActivity 로 이동
                     if (cardCreateViewModel.isCardMeOrYou!!) {
                         // 2-1. 내 카드나 작성 => CardCreateCompleteActivity 로 보내줘야 함.
-                        val intent = Intent(this@CardCreateActivity, CardCreateCompleteActivity::class.java)
+                        val intent =
+                            Intent(this@CardCreateActivity, CardCreateCompleteActivity::class.java)
                         intent.putExtra(
                             BaseViewUtil.IS_CARD_ME_OR_YOU,
                             cardCreateViewModel.isCardMeOrYou
@@ -295,7 +314,10 @@ class CardCreateActivity :
                             BaseViewUtil.CARD_IMG,
                             cardCreateViewModel.uri.value.toString()
                         ) // 심볼 - null, 갤러리 - uri 값
-                        intent.putExtra(BaseViewUtil.CARD_TITLE, cardCreateViewModel.etKeywordText.value)
+                        intent.putExtra(
+                            BaseViewUtil.CARD_TITLE,
+                            cardCreateViewModel.etKeywordText.value
+                        )
 
                         binding.tvCardcreateComplete.isClickable = false
                         startActivity(intent)
@@ -309,7 +331,10 @@ class CardCreateActivity :
                         )
 
                         val newIntent =
-                            Intent(this@CardCreateActivity, OtherCardCreateCompleteActivity::class.java)
+                            Intent(
+                                this@CardCreateActivity,
+                                OtherCardCreateCompleteActivity::class.java
+                            )
 
                         newIntent.putExtra(
                             BaseViewUtil.IS_CARDPACK_OR_MAINCARD, isCardPackOrMainCard

--- a/app/src/main/java/org/cardna/presentation/ui/cardpack/view/CardPackFragment.kt
+++ b/app/src/main/java/org/cardna/presentation/ui/cardpack/view/CardPackFragment.kt
@@ -1,7 +1,9 @@
 package org.cardna.presentation.ui.cardpack.view
 
-import android.graphics.Color
+import android.R
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import androidx.databinding.DataBindingUtil
@@ -11,9 +13,6 @@ import androidx.viewpager2.widget.ViewPager2
 import com.amplitude.api.Amplitude
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
-import land.sungbin.systemuicontroller.setNavigationBarColor
-import land.sungbin.systemuicontroller.setSystemBarsColor
-import org.cardna.R
 import org.cardna.databinding.CardpackCustomTablayoutBinding
 import org.cardna.databinding.FragmentCardPackBinding
 import org.cardna.presentation.MainActivity
@@ -22,8 +21,10 @@ import org.cardna.presentation.ui.cardpack.adapter.CardPackTabLayoutAdapter
 import org.cardna.presentation.ui.cardpack.viewmodel.CardPackViewModel
 import timber.log.Timber
 
+
 @AndroidEntryPoint
-class CardPackFragment : BaseViewUtil.BaseFragment<FragmentCardPackBinding>(R.layout.fragment_card_pack) {
+class CardPackFragment :
+    BaseViewUtil.BaseFragment<FragmentCardPackBinding>(org.cardna.R.layout.fragment_card_pack) {
     private val cardPackViewModel: CardPackViewModel by activityViewModels()
     private lateinit var cardPackTabLayoutAdapter: CardPackTabLayoutAdapter // tabLayout 에 data 띄워주는 adapter
 
@@ -31,6 +32,7 @@ class CardPackFragment : BaseViewUtil.BaseFragment<FragmentCardPackBinding>(R.la
         super.onCreate(savedInstanceState)
         Timber.e("bottomtest CardPackFragment onCreate")
     }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         Amplitude.getInstance().logEvent("CardPack")
@@ -43,7 +45,7 @@ class CardPackFragment : BaseViewUtil.BaseFragment<FragmentCardPackBinding>(R.la
         // 카드팩프래그먼트에서 카드를 눌러 카드 상세페이지로 가서 삭제한다음 왔을 때, 카드팩의 카드들이 업데이트 되어야 하므로 onResume 이 필요
         super.onResume()
         Timber.e("bottomtest CardPackFragment onResume")
-        if(cardPackViewModel.id.value == null) // 내 카드팩일때만 onResume 해주면 됨.
+        if (cardPackViewModel.id.value == null) // 내 카드팩일때만 onResume 해주면 됨.
             cardPackViewModel.setTotalCardCnt()
         binding.vpCardpack.setCurrentItem(cardPackViewModel.tabPosition.value ?: 0, false)
     }
@@ -99,7 +101,7 @@ class CardPackFragment : BaseViewUtil.BaseFragment<FragmentCardPackBinding>(R.la
     private fun createTabLayout(tabName: String): View { // 각 탭 레이아웃에 탭의 뷰 디자인 하는 메서드
         val tabBinding: CardpackCustomTablayoutBinding = DataBindingUtil.inflate(
             LayoutInflater.from(requireContext()),
-            R.layout.cardpack_custom_tablayout,
+            org.cardna.R.layout.cardpack_custom_tablayout,
             null,
             false
         )
@@ -109,15 +111,15 @@ class CardPackFragment : BaseViewUtil.BaseFragment<FragmentCardPackBinding>(R.la
                 "카드나" -> {
                     tvCardmeTab.text = tabName
                     isCardme = true
-                    ivCardpackTab.setImageResource(R.drawable.ic_selector_cardpack_tab_cardme)
-                    viewCardpackLine.setBackgroundResource(R.drawable.ic_selector_cardpack_tab_cardme_line)
+                    ivCardpackTab.setImageResource(org.cardna.R.drawable.ic_selector_cardpack_tab_cardme)
+                    viewCardpackLine.setBackgroundResource(org.cardna.R.drawable.ic_selector_cardpack_tab_cardme_line)
                 }
 
                 "카드너" -> {
                     tvCardyouTab.text = tabName
                     isCardme = false
-                    ivCardpackTab.setImageResource(R.drawable.ic_selector_cardpack_tab_cardyou)
-                    viewCardpackLine.setBackgroundResource(R.drawable.ic_selector_cardpack_tab_cardyou_line)
+                    ivCardpackTab.setImageResource(org.cardna.R.drawable.ic_selector_cardpack_tab_cardyou)
+                    viewCardpackLine.setBackgroundResource(org.cardna.R.drawable.ic_selector_cardpack_tab_cardyou_line)
                 }
             }
         }
@@ -132,12 +134,20 @@ class CardPackFragment : BaseViewUtil.BaseFragment<FragmentCardPackBinding>(R.la
 
             // 카드추가버튼에 카드나 카드너 추가 바텀씻 올라오는 리스너 달기
             binding.ctlAddCardBg.setOnClickListener {
+                binding.ctlAddCardBg.isClickable = false
                 (activity as MainActivity).showBottomDialogCardFragment()
+
+                val handler = Handler(Looper.getMainLooper())
+                handler.postDelayed({
+                        binding.ctlAddCardBg.isClickable = true
+                    },1000
+                ) // 1초 딜레이 후 다시 클릭 가능하도록
             }
 
             // 나머지 분기처리는 xml 상에서 삼항연산자 이용
         }
     }
+
     private fun setInitPagePosition() {
         binding.vpCardpack.registerOnPageChangeCallback(object :
             ViewPager2.OnPageChangeCallback() {


### PR DESCRIPTION
## 구현한 사항
- [x] 바텀 다이얼로그 빠르게 연속으로 두 번 클릭 시, 앱 터지는 오류 방지 위해 바텀 다이얼로그 한번만 띄워지도록 방지하는 코드 추가

## 관련 이슈
- #111 